### PR TITLE
HUGE performance boost + update library to use 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ btleplug = "0.10.5"
 futures = "0.3.28"
 pretty_env_logger = "0.5.0"
 serde = { version = "1.0.164", features = ["derive"] }
-sysinfo = "0.29.2"
+sysinfo = "0.30.5"
 tokio = { version = "1.28.2", features = ["full"] }
 uuid = "1.4.0"
 xmltojson = { git = "https://github.com/rtyler/xmltojson", version = "0.1.3" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use futures::stream::StreamExt;
 use std::collections::HashMap;
 use std::error::Error;
 use std::io::{self, Write};
+use sysinfo::{System};
 
 mod flipper_manager;
 mod helpers;
@@ -23,9 +24,11 @@ async fn data_sender(flipper: Peripheral) {
         }
     };
     println!("Now you can launch PC Monitor app on your Flipper");
-
+    
+    // Reuse system variable in loop (small performance and RAM boost)
+    let mut system_info = sysinfo::System::new_all();
     loop {
-        let systeminfo = system_info::SystemInfo::get_system_info().await;
+        let systeminfo = system_info::SystemInfo::get_system_info(&mut system_info).await;
         let systeminfo_bytes = bincode::serialize(&systeminfo).unwrap();
         // println!("Writing {:?} to Flipper", systeminfo_bytes);
 

--- a/src/system_info.rs
+++ b/src/system_info.rs
@@ -1,6 +1,6 @@
 use crate::helpers::{avg_vecu32, nvd_r2u32, pop_4u8};
 use serde::Serialize;
-use sysinfo::{CpuExt, SystemExt};
+use sysinfo::{System, MemoryRefreshKind};
 use tokio::io::AsyncReadExt;
 
 /*
@@ -41,9 +41,10 @@ impl SystemInfo {
         .to_owned()
     }
 
-    pub async fn get_system_info() -> Self {
-        let mut system_info = sysinfo::System::new_all();
-        system_info.refresh_all();
+    pub async fn get_system_info(system_info: &mut sysinfo::System) -> Self {
+        // Need to refresh only CPU and RAM => big boost when combined with reusing system_info
+        // system_info.refresh_all();
+        system_info.refresh_memory_specifics(MemoryRefreshKind::new().with_ram());
         let base: u64 = 1024;
 
         let ram_max = system_info.total_memory();

--- a/src/system_info.rs
+++ b/src/system_info.rs
@@ -71,8 +71,8 @@ impl SystemInfo {
             _ => 0,
         };
 
-        // Refresh CPU before reading to get correct values
-        system_info.refresh_cpu();
+        // Refresh only CPU usage before reading
+        system_info.refresh_cpu_usage();
         SystemInfo {
             cpu_usage: avg_vecu32(
                 system_info


### PR DESCRIPTION
HUGE performance boost + update library to use refresh_memory_specifics() for RAM-only refresh

Went **from**:
![image](https://github.com/TheSainEyereg/flipper-pc-monitor-backend/assets/24632372/d9c4748b-a6ed-45b7-bc8d-4260935b1314)

**To**:
![image](https://github.com/TheSainEyereg/flipper-pc-monitor-backend/assets/24632372/cd11b157-eb07-4b92-b2f5-893914e36f76)

When running the release build I sometimes get 0% or 0.1% for some periods, but usually stables out at 0.1 - 0.5% with very low power usage when compared to previous Medium usage.